### PR TITLE
Fix: TypeError: Cannot read properties of undefined (reading '0') at TournamentBracketModal.render

### DIFF
--- a/srcs/frontend/src/views/components/game/tournamentBracketModal.js
+++ b/srcs/frontend/src/views/components/game/tournamentBracketModal.js
@@ -4,7 +4,6 @@ import Component from "../../../library/component.js";
 export default class TournamentBracketModal extends Component {
 	constructor() {
 		super({ element: document.getElementById("tournamentBracketModal") });
-		this.render();
 		store.events.subscribe("roundChange", () =>
 			this.showTournamentBracketModal()
 		);


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [x] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

### Summary
- (버그 수정)TypeError: Cannot read properties of undefined (reading '0') at TournamentBracketModal.render

### Description
- game.js, tournament.js 통합과정에서 발생한 undefined 참조 에러 해결

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading '0')
    at TournamentBracketModal.render (tournamentBracketModal.js:40:64)
    at new TournamentBracketModal (tournamentBracketModal.js:13:8)
    at new Game (game.js:22:28)
    at router (router.js:54:33)
    at navigateTo (router.js:30:2)
    at singleGameActionHandler.startGame (singleGameActionHandler.js:64:69)
    at Socket.eval (gameActionHandler.js:59:9)
    at Emitter.emit (index.mjs:140:20)
    at Socket.emitEvent (socket.js:505:20)
    at eval (socket.js:565:51)
```

### Issue Number