### PR TITLE
Fix: emitUserReadyEvent에서 async 키워드 삭제

### DIFF
--- a/srcs/frontend/src/store/actions/gameActionHandler.js
+++ b/srcs/frontend/src/store/actions/gameActionHandler.js
@@ -188,7 +188,7 @@ export default class gameActionHandler {
 	/**
 	 * @description 유저가 준비되었다는 이벤트를 서버로 보냄
 	 */
-	async emitUserReadyEvent() {
+	emitUserReadyEvent() {
 		const state = this.context.state;
 
 		if (!this.socket)


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [x] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

### Summary
Bug: Unchecked runtime.lastError 발생하는데, emitUserReadyEvent에서 async 키워드를 제거하여 문제를 해결했다.


### Description


### Issue Number