### PR TITLE
Fix/change gameovermodal zindex

### DIFF
--- a/srcs/frontend/src/static/css/styles.css
+++ b/srcs/frontend/src/static/css/styles.css
@@ -28,6 +28,14 @@ canvas {
     background-color: rgba(0, 0, 0, 0.4);
 }
 
+#gameOverModal {
+    z-index: 3;
+}
+
+#tournamentBracketModal {
+    z-index: 2;
+}
+
 .custom-modal-dialog {
     position: relative;
     margin: auto;
@@ -395,7 +403,7 @@ canvas {
     justify-content: space-between;
 }
 
-.game-item .details .name,
+game-item .details .name,
 .game-item .details .score {
     margin: 0 10px;
 }

--- a/srcs/frontend/src/static/css/styles.css
+++ b/srcs/frontend/src/static/css/styles.css
@@ -403,7 +403,7 @@ canvas {
     justify-content: space-between;
 }
 
-game-item .details .name,
+.game-item .details .name,
 .game-item .details .score {
     margin: 0 10px;
 }


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [x] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

### Summary
- styles.css에서 z-index를 이용해 gameOverModal이 항상 tournamentBracketModal 보다 상위 레이어에 보일 수 있도록 변경함

### Description


### Issue Number