### PR TITLE
Fix: 네임스페이스별로 나눠서 socket 연결 관리하도록 수정

### DIFF
--- a/srcs/frontend/src/store/actions.js
+++ b/srcs/frontend/src/store/actions.js
@@ -36,7 +36,6 @@ function joinGame(context, payload) {
 
 	const gameHandler = getGameHandler(context);
 	gameHandler.connectSocket(payload);
-	gameHandler.bindSocketEvents();
 }
 
 function startRound(context) {

--- a/srcs/frontend/src/store/actions/singleGameActionHandler.js
+++ b/srcs/frontend/src/store/actions/singleGameActionHandler.js
@@ -31,7 +31,9 @@ export default class singleGameActionHandler extends GameActionHandler {
 	 * @param {object} payload { namespace, intraId, nickname, speedUp}
 	 */
 	async startGame(payload) {
-		console.log("EVENT: userFullEvent: singleGameActionHandler.startGame");
+		console.groupCollapsed(
+			"EVENT: userFullEvent: singleGameActionHandler.startGame"
+		);
 
 		const state = this.context.state;
 
@@ -42,20 +44,22 @@ export default class singleGameActionHandler extends GameActionHandler {
 		this.userIndex = this.intraIdList.indexOf(state.intraId);
 		this.userSide = this.userIndex % 2 === 0 ? Side.LEFT : Side.RIGHT;
 		this.matchQueue = [0, 1];
+
+		console.log(" - roomName=", payload.roomName);
+		console.log(" - intraId=", payload.intraId);
+		console.log(" - nickname=", payload.nickname);
+		console.log(" - userIndex=", this.userIndex);
+		console.log(" - userSide=", this.userSide);
+
 		this.initScores();
 		this.initPositions();
 		this.updateGameContext();
 		this.context.commit("setEndReason", { endReason: "normal" });
 
-		console.log("  roomName=", payload.roomName);
-		console.log("  intraId=", payload.intraId);
-		console.log("  nickname=", payload.nickname);
-		console.log("  userIndex=", this.userIndex);
-		console.log("  userSide=", this.userSide);
-
 		// 게임 페이지로 이동
 		navigateTo("/game");
 		this.context.commit("setGameStatus", { gameStatus: "playing" });
+		console.groupEnd();
 	}
 
 	/**
@@ -63,7 +67,9 @@ export default class singleGameActionHandler extends GameActionHandler {
 	 * @param {object} payload {reason}
 	 */
 	async endGame(payload) {
-		console.log("EVENT: endGame: singleGameActionHandler.endGame");
+		console.groupCollapsed(
+			"EVENT: endGame: singleGameActionHandler.endGame"
+		);
 		console.log(" reason=", payload.reason);
 
 		const state = this.context.state;
@@ -76,11 +82,12 @@ export default class singleGameActionHandler extends GameActionHandler {
 			this.context.commit("setWinner", { winner: winner });
 		}
 
-		if (this.socket) {
+		if (!this.gameEnded) {
 			this.socket.disconnect();
-			this.socket = null;
+			this.gameEnded = true;
 		}
 		this.context.commit("setEndReason", { endReason: payload.reason });
 		this.context.commit("setGameStatus", { gameStatus: "ended" });
+		console.groupEnd();
 	}
 }

--- a/srcs/frontend/src/store/actions/tournamentActionHandler.js
+++ b/srcs/frontend/src/store/actions/tournamentActionHandler.js
@@ -32,7 +32,9 @@ export default class tournamentActionHandler extends GameActionHandler {
 	 * @param {object} payload { roomName, intraId, nickname}
 	 */
 	async startGame(payload) {
-		console.log("EVENT: userFullEvent: tournamentActionHandler.startGame");
+		console.groupCollapsed(
+			"EVENT: userFullEvent: tournamentActionHandler.startGame"
+		);
 		const state = this.context.state;
 
 		// 게임 시작 시 게임 정보 초기화
@@ -42,6 +44,13 @@ export default class tournamentActionHandler extends GameActionHandler {
 		this.userIndex = this.intraIdList.indexOf(state.intraId);
 		this.userSide = this.userIndex % 2 === 0 ? Side.LEFT : Side.RIGHT;
 		this.matchQueue = [0, 1, 2, 3];
+
+		console.log(" - roomName=", payload.roomName);
+		console.log(" - intraId=", payload.intraId);
+		console.log(" - nickname=", payload.nickname);
+		console.log(" - userIndex=", this.userIndex);
+		console.log(" - userSide=", this.userSide);
+
 		this.initScores();
 		this.initPositions();
 		this.initTournamentPlayers();
@@ -53,6 +62,7 @@ export default class tournamentActionHandler extends GameActionHandler {
 		// 게임 페이지로 이동
 		navigateTo("/game");
 		this.context.commit("setRound", { round: 1 });
+		console.groupEnd();
 	}
 
 	/**
@@ -100,7 +110,9 @@ export default class tournamentActionHandler extends GameActionHandler {
 	 * @param {object} payload {round, reason, winnerSide}
 	 */
 	async endGame(payload) {
-		console.log("EVENT: endGame: tournamentActionHandler.endGame");
+		console.groupCollapsed(
+			"EVENT: endGame: tournamentActionHandler.endGame"
+		);
 		console.log(" round: ", payload.round, " reason: ", payload.reason);
 		console.log(" winnerSide: ", payload.winnerSide);
 		const state = this.context.state;
@@ -108,15 +120,16 @@ export default class tournamentActionHandler extends GameActionHandler {
 		if (payload.reason === "normal") {
 			this.endRound(payload);
 			if (payload.round < 3) {
+				console.groupEnd();
 				return;
 			}
 			this.context.commit("setWinner", {
 				winner: state.tournamentWinner.round3,
 			});
 		}
-		if (this.socket) {
+		if (!this.gameEnded) {
 			this.socket.disconnect();
-			this.socket = null;
+			this.gameEnded = true;
 		}
 		this.context.commit("setEndReason", { endReason: payload.reason });
 		if (
@@ -125,12 +138,14 @@ export default class tournamentActionHandler extends GameActionHandler {
 		) {
 			this.context.commit("setGameStatus", { gameStatus: "ended" });
 		}
+		console.groupEnd();
 	}
 
 	/**
 	 * @description tournament 참여자의 닉네임을 리스트 형태로 tournamentPlayer에 저장
 	 */
 	initTournamentPlayers() {
+		console.log("initTournamentPlayers: ");
 		this.context.commit("setTournamentPlayer", {
 			tournamentPlayer: this.nicknameList,
 		});
@@ -140,6 +155,7 @@ export default class tournamentActionHandler extends GameActionHandler {
 	 * @description round별로 tournament 참여자의 점수를 초기화
 	 */
 	initTournamentScores() {
+		console.log("initTournamentScores: ");
 		this.context.commit("setTournamentScore", {
 			tournamentScore: {
 				round1: ["-", "-"],
@@ -153,6 +169,7 @@ export default class tournamentActionHandler extends GameActionHandler {
 	 * @description round별로 tournament 참여자의 우승자를 초기화
 	 */
 	initTournamentWinners() {
+		console.log("initTournamentWinners: ");
 		this.context.commit("setTournamentWinner", {
 			tournamentWinner: {
 				round1: "-",


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [x] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

### Summary
네임스페이스별로 나눠서 socket 연결 관리하도록 수정함.

### Description
현재 게임 모드에 따라서 single, tournament 두 개의 네임스페이스로 socket에 연결하고 있다.
기존에는 매 게임마다 io를 호출하여 Socket.IO.Client를 생성하고 있었다.
하지만, 비효율적이고 게임 모드가 바뀌는 상황(ex. tournament 모드를 플레이한 후, single 모드를 플레이)에서 socket을 연결하면서 보내는 query가 업데이트되지 않는 문제가 발생했다.
따라서, 네임스페이스(single, tournament) 별로 두 개의 Socket.IO.Client 객체만 생성하고, query에 담기는 정보만 업데이트하여 connect를 시도하는 방향으로 수정하였다.

### Issue Number