### PR TITLE
Fix : main log 전환 시에 node 인식 오류

### DIFF
--- a/srcs/frontend/src/views/components/tournamentRecord.js
+++ b/srcs/frontend/src/views/components/tournamentRecord.js
@@ -113,7 +113,7 @@ export default class TournamentRecord extends Component {
 				tournamentList.appendChild(tournamentItem);
 			});
 		} catch (error) {
-			console.error("Error parsing tournament data: ", error);
+			// console.error("Error parsing tournament data: ", error);
 		}
 	}
 
@@ -175,7 +175,7 @@ export default class TournamentRecord extends Component {
 			try {
 				window.open(link, "_blank");
 			} catch (error) {
-				console.error("Failed to open window:", error);
+				// console.error("Failed to open window:", error);
 			}
 		};
 

--- a/srcs/frontend/src/views/components/tournamentRecord.js
+++ b/srcs/frontend/src/views/components/tournamentRecord.js
@@ -172,11 +172,23 @@ export default class TournamentRecord extends Component {
 		// Add click event to open window
 		const link = tournamentData.etherscan;
 		newComponent.onclick = function () {
-			window.open(link, "_blank");
+			try {
+				window.open(link, "_blank");
+			} catch (error) {
+				console.error("Failed to open window:", error);
+			}
 		};
 
 		const originalComponent = document.getElementById("etherscan");
-		originalComponent.parentNode.replaceChild(newComponent, originalComponent);
+		if (originalComponent) {
+			try {
+				originalComponent.parentNode.replaceChild(newComponent, originalComponent);
+			} catch (error) {
+				// console.error("Failed to replace component:", error);
+			}
+		} else {
+			// console.error("Original component not found.");
+		}
 	}
 
 	createFormattedDate(unix_timestamp) {

--- a/srcs/game/blockchain/tournament.sol
+++ b/srcs/game/blockchain/tournament.sol
@@ -24,8 +24,6 @@ contract TournamentStorage {
     Tournament[] tournaments;
 
     function store(Tournament memory one_tournament) public {
-        // 시간을 기록
-        // one_tournament.timestamp = block.timestamp;
         tournaments.push(one_tournament);
     }
 


### PR DESCRIPTION
### PR Type
<!— Please check the one that applies to this PR using "[x]" —>

- [ ] Feat(기능 추가)
- [ ] Fix(버그 수정)
- [ ] Remove(파일 삭제)
- [ ] Rename(파일 이름 변경)
- [ ] Comment(코드 내 주석 추가, 수정, 삭제)
- [ ] Test(테스트 추가, 테스트 리팩토링)
- [ ] Refactor(코드 리팩토링)
- [ ] Style(코드 형식 변경, 세미콜론 추가)
- [ ] Design(사용자 UI, CSS 변경)
- [ ] Docs(문서 수정)
- [ ] Build (빌드 관련)
- [ ] Other - Please Describe:

### Summary

1. 현재 토너먼트 컴포넌트는 로그를 불러오고, 형성됩니다. 
2. 토너먼트 컴포넌트가 형성되기 전에 html이 전환되면 기존 노드를 찾지 못해 에러를 발생했습니다.
3. 예외 처리를 진행했습니다.

### Description


### Issue Number